### PR TITLE
Uses `8.0.x` instead of `8.x` for Drupal verison.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -25,7 +25,7 @@ module.exports = yeoman.generators.Base.extend({
       message: 'Which version of ' + chalk.red('Drupal core') + ' would you like to use?',
       default: '8.x',
       choices: [
-        {'name': 'Drupal 8', 'value': '8.x'},
+        {'name': 'Drupal 8', 'value': '8.0.x'},
         {'name': 'Drupal 7', 'value': '7.x'}
       ]
     }];


### PR DESCRIPTION
The initial build fails since `8.x` is no longer a valid version:

```
Running "drush:make" (drush) task
Beginning to build src/project.make.                                                                                                                                      [ok]
Could not locate drupal version 8.x.                                                                                                                                      [error]
Warning: Drush failed: 1 Use --force to continue.
```
