### PR TITLE
adding ability to pass in theme build scripts from other Yeoman Generators

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -170,6 +170,10 @@ module.exports = yeoman.generators.Base.extend({
           themeOpts.gruntTask = this.options.themeGruntTask;
         }
 
+        if (this.options.themeScripts) {
+          themeOpts.scripts = this.options.themeScripts;
+        }
+
         if (!gcfg.hasOwnProperty('themes')) {
           gcfg.themes = {};
         }


### PR DESCRIPTION
A parent generator can now use [`.composeWith()`](http://yeoman.io/authoring/composability.html) and pass in theme compile settings like this:

``` js
      this.composeWith('gadget', { options: {
        themeName: this.themeName,
        themePath: this.themePath,
        themeScripts: {
          "compile-theme": "npm run compile"
        }
      }});
```
