### PR TITLE
Ensuring lib folder will get added when installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "mocha"
   },
   "files": [
-    "app"
+    "app",
+    "lib"
   ],
   "keywords": [
     "build",


### PR DESCRIPTION
Currently, getting this via an `npm install` **does not** include the `lib/` folder - a crucial piece. When testing via a `git clone` it works. This changes adds the `lib/` folder to installs.
