### PR TITLE
Adding newer versions of node to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - '4.1'
+  - '4.0'
   - '0.12'
   - '0.10'


### PR DESCRIPTION
I've also noticed that we don't have a [Travis build for this repo](https://travis-ci.org/phase2/generator-gadget) and it appears all we have to do is go to the [phase2 Travis profile page](https://travis-ci.org/profile/phase2) and turn on Travis for this repo.
