### PR TITLE
Switch from serve.profile to project.profile.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -142,7 +142,7 @@ module.exports = yeoman.generators.Base.extend({
         gcfg.themes[options.themeName] = themeOpts;
       }
 
-      gcfg.serve = { "profile": options.drupalDistro.profile };
+      gcfg.project = { "profile": options.drupalDistro.profile };
       gcfg.generated = { name: this.pkg.name, version: this.pkg.version };
 
       this.fs.writeJSON('Gruntconfig.json', gcfg);


### PR DESCRIPTION
GDT master has deprecated the serve.profile setting in favor of project.profile.
