### PR TITLE
Inject memcache into project.make when memcache is specified

### DIFF
--- a/app/distros/drupal.js
+++ b/app/distros/drupal.js
@@ -25,8 +25,15 @@ function init() {
   module.drushMakeFile = function(yo, options, done) {
     var tokens = {
       drupalDistroRelease: options.drupalDistroRelease,
-      coreCompatibility: options.drupalDistroVersion
+      coreCompatibility: options.drupalDistroVersion,
+      memcache: false
     };
+
+    if (options['memcacheVersion']) {
+      tokens.memcache = true;
+      tokens.memcacheVersion = options['memcacheVersion'];
+    }
+
     yo.fs.copyTpl(
       yo.templatePath('drupal/project.make'),
       yo.destinationPath('src/project.make'),

--- a/app/index.js
+++ b/app/index.js
@@ -39,7 +39,7 @@ module.exports = yeoman.generators.Base.extend({
   // Install Grunt Drupal Tasks, either the latest published version or the
   // current development version in the master branch.
   installGDT: function() {
-    require('./gdt')(this).install();
+    //require('./gdt')(this).install();
   },
 
   // Determine the latest stable release for the requested Drupal core version.
@@ -63,6 +63,22 @@ module.exports = yeoman.generators.Base.extend({
       options.drupalDistroRelease = version;
       done();
     }.bind(this));
+  },
+
+  memcacheVersion: function() {
+    if (options.cacheInternal == 'memcache') {
+      var done = this.async();
+      require('../lib/drupalProjectVersion')
+        .latestRelease('memcache', '7.x', done, function(err, version, done) {
+          if (err) {
+            this.log.error(err);
+            return done(err);
+          }
+          options.memcacheVersion = version;
+          done();
+        }.bind(this)
+      );
+    }
   },
 
   writing: {

--- a/app/index.js
+++ b/app/index.js
@@ -48,14 +48,15 @@ module.exports = yeoman.generators.Base.extend({
     options.drupalDistroRelease = options.drupalDistroVersion;
 
     // Handle version used by updates.drupal.org for 8.x.x releases.
-    var majorVersionForUpdateSystem = options.drupalDistroVersion;
-    if (majorVersionForUpdateSystem.match(/^8\.\d+\.x$/)) {
-      majorVersionForUpdateSystem = '8.x';
+    options.majorVersionForUpdateSystem = options.drupalDistroVersion;
+    if (options.majorVersionForUpdateSystem.match(/^8\.\d+\.x$/)) {
+      options.majorVersionForUpdateSystem = '8.x';
     }
+
 
     // Find the latest stable release for the Drupal distro version.
     var done = this.async();
-    options.drupalDistro.releaseVersion(majorVersionForUpdateSystem, done, function(err, version, done) {
+    options.drupalDistro.releaseVersion(options.majorVersionForUpdateSystem, done, function(err, version, done) {
       if (err) {
         this.log.error(err);
         return done(err);
@@ -69,12 +70,12 @@ module.exports = yeoman.generators.Base.extend({
     if (options.cacheInternal == 'memcache') {
       var done = this.async();
       require('../lib/drupalProjectVersion')
-        .latestRelease('memcache', '7.x', done, function(err, version, done) {
+        .latestRelease('memcache', options.majorVersionForUpdateSystem, done, function(err, version, done) {
           if (err) {
             this.log.error(err);
             return done(err);
           }
-          options.memcacheVersion = version;
+          options.memcacheVersion = version.substr(4);
           done();
         }.bind(this)
       );

--- a/app/templates/drupal/project.make
+++ b/app/templates/drupal/project.make
@@ -8,3 +8,5 @@ defaults[projects][type] = "module"
 projects[drupal][version] = "<%= drupalDistroRelease %>"
 
 ;; Project-specific Dependencies
+
+<% if (memcache) { %><%- include ../make-memcache -%><% } %>

--- a/app/templates/make-memcache.ejs
+++ b/app/templates/make-memcache.ejs
@@ -1,0 +1,2 @@
+; Provides cache drivers for memcache. Module installation not required.
+projects[memcache][version] = "<%= memcacheVersion %>"

--- a/app/templates/project-distro.make
+++ b/app/templates/project-distro.make
@@ -14,3 +14,4 @@ projects[<%= drupalDistroName %>][subdir] = ''
 
 ;; Project-specific Dependencies
 
+<% if (memcache) { %><%- include make-memcache -%><% } %>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "request": "2.54.0",
     "require-directory": "^2.1.1",
     "xml2js": "0.4.6",
-    "yeoman-generator": "0.18.10",
+    "yeoman-generator": "0.21.1",
     "yosay": "1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
1. Updates yeoman-generator, we can now use ejs partials along with every other change since 0.18.
2. If cacheInternal is specified as `memcache`, the latest stable memcache release for the current Drupal version will be injected into the project.make file.
3. The previous bug of requiring a forced override on every generator run to create atriums drupal-org-core.make file is fixed.

The cacheInternal setting can be invoked when running gadget as `yo gadget --cacheInternal=memcache`.
