### PR TITLE
Avoid template processing for GDT and Drupal

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -84,14 +84,18 @@ module.exports = yeoman.generators.Base.extend({
 
   writing: {
     template: function () {
-      this.directory(
+      this._directory(
         this.destinationPath('node_modules/grunt-drupal-tasks/example'),
-        this.destinationPath()
+        this.destinationPath(),
+        null,
+        true
       );
 
-      this.directory(
+      this._directory(
         this.templatePath(path.resolve(options.drupalDistro.id, options.drupalDistroVersion)),
-        this.destinationPath()
+        this.destinationPath(),
+        null,
+        true
       );
     },
 


### PR DESCRIPTION
Using `this._directory()` instead of `this.directory()` to avoid template processing, which conflicts with placeholders in GDT config.

`this._directory()` is used instead of `this.bulkDirectory()` because the latter is asynchronous but does not provide a callback.

cc @EvanLovely @grayside 
