### PR TITLE
Fixing handling of --drupalDistro CLI option as prompt override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ node_js:
   - '0.12'
   - '0.10'
 install:
-  - npm install -g yo
-  - npm install -g mocha
+  - npm install -g grunt-cli mocha yo
   - ls -lRa
 script:
   - npm install
@@ -15,3 +14,4 @@ script:
   - mkdir test_run
   - cd test_run
   - yo gadget --projectName=drupal8 --projectDescription="test drupal8 project" --drupalDistro=drupal --drupalDistroVersion=8.x
+  - grunt

--- a/app/index.js
+++ b/app/index.js
@@ -24,6 +24,11 @@ module.exports = yeoman.generators.Base.extend({
     var self = this;
     var done = this.async();
 
+    if (this.options.hasOwnProperty('drupalDistro') && typeof this.options.drupalDistro === 'string') {
+      var distros = require('../app/distros');
+      this.options.drupalDistro = distros[this.options.drupalDistro];
+    }
+
     var prompts = require('../lib/prompts');
     prompts = _.filter(prompts, function (item) {
       return _.isUndefined(self.options[item.name]);


### PR DESCRIPTION
This fixes the first reason automated tests were failing. `--drupalDistro` wasn't working because when the prompt returns this option it returns a distro settings object, but only the text value was available when set via CLI option.

This resulted in the following error:

```
TypeError: undefined is not a function

    at module.exports.yeoman.generators.Base.extend.configuring.getDistroRelease (/home/travis/build/phase2/generator-gadget/app/index.js:54:28)
```

This also adds a run of grunt to the Travis test script.

Note: With the above error fixed, the automated tests now fail due to the processing of templates, which is addressed by #33 and #35.
