### PR TITLE
Remove base_url from behat.yml so environment variables can win

### DIFF
--- a/app/templates/gdt/test/behat.yml
+++ b/app/templates/gdt/test/behat.yml
@@ -10,7 +10,6 @@ default:
       goutte: ~
       selenium2: ~
       zombie: ~
-      base_url: http://127.0.0.1:8080
       javascript_session: 'zombie'
     Drupal\DrupalExtension:
       blackbox: ~


### PR DESCRIPTION
Fixes overall test error with recent versions of Behat not honoring the environment-injected base_url.
