### PR TITLE
Updating Node.js versions tested by Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '4.1'
-  - '4.0'
+  - '5'
+  - '4.2'
   - '0.12'
   - '0.10'
 install:


### PR DESCRIPTION
Removing 4.0 and 4.1, adding 4.2 and 5 (latest 5.x release).

cc @EvanLovely 
