### PR TITLE
Deprecate support for Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - '5'
   - '4.2'
   - '0.12'
-  - '0.10'
 install:
   - npm install -g grunt-cli mocha
   - ls -lRa

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ system with the Grunt Drupal Tasks kit.
 
 ## Requirements
 
-* Install _Node.js v0.10.0 or better_ either using a
+* Install _Node.js v0.12.0 or better_ either using a
 <a href="https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager">package manager</a>
 like apt-get, brew, or yum or a
 <a href="http://nodejs.org/download/">standalone installer</a>.


### PR DESCRIPTION
Updating README.md and Travis CI script to deprecate support/testing of Node.js 0.10, as already specified in package.json.
