### PR TITLE
Fix broken directory exist check.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -102,11 +102,7 @@ module.exports = yeoman.generators.Base.extend({
         options.drupalDistroVersion
       );
 
-      var fs = require('fs');
-      if (
-        (fs.existsSync && fs.existsSync(srcFiles))
-        || fs.accessSync(srcFiles, fs.R_OK)
-      ) {
+      if (gadget.fsExistsSync(srcFiles)) {
         this.fs.copy(
           path.resolve(srcFiles),
           this.destinationRoot(),

--- a/lib/util.js
+++ b/lib/util.js
@@ -28,3 +28,22 @@ module.exports.npmVersion = function(name, relativeRepoUrl, useMaster) {
     return '~' + _.trim(version);
   }
 }
+
+module.exports.fsExistsSync = function(path) {
+  var fs = require('fs');
+
+  if (fs.existsSync) {
+    return fs.existsSync(path);
+  }
+  else {
+    try {
+      fs.accessSync(filename);
+      return true;
+    }
+    catch(ex) {
+      return false;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Atrium generation is currently crashing and burning, because the existing implementation of fs.access slid in without the necessary try/catch business.
