### PR TITLE
postinstall: cd <theme> && npm install

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -142,7 +142,7 @@ module.exports = yeoman.Base.extend({
       pkg.name = options.projectName;
       pkg.description = options.projectDescription;
 
-      if (!pkg['scripts'] && options['themePath']) {
+      if (!pkg['scripts']) {
         pkg.scripts = {};
       }
       if (!pkg.scripts['postinstall'] && options['themePath']) {

--- a/app/index.js
+++ b/app/index.js
@@ -142,10 +142,10 @@ module.exports = yeoman.Base.extend({
       pkg.name = options.projectName;
       pkg.description = options.projectDescription;
 
-      if (!pkg['scripts']) {
+      if (!pkg['scripts'] && options['themePath']) {
         pkg.scripts = {};
       }
-      if (!pkg.scripts['postinstall']) {
+      if (!pkg.scripts['postinstall'] && options['themePath']) {
         pkg.scripts['postinstall'] = 'cd ' + options.themePath + ' && npm install';
       }
 

--- a/app/index.js
+++ b/app/index.js
@@ -142,6 +142,13 @@ module.exports = yeoman.Base.extend({
       pkg.name = options.projectName;
       pkg.description = options.projectDescription;
 
+      if (!pkg['scripts']) {
+        pkg.scripts = {};
+      }
+      if (!pkg.scripts['postinstall']) {
+        pkg.scripts['postinstall'] = 'cd ' + options.themePath + ' && npm install';
+      }
+
       this.fs.writeJSON('package.json', pkg);
     },
 

--- a/app/templates/gdt/package.json
+++ b/app/templates/gdt/package.json
@@ -7,6 +7,9 @@
     "npm": "2.x"
   },
   "private": true,
+  "scripts": {
+    "start": "grunt --timer"
+  },
   "dependencies": {
     "grunt": "~0.4.5",
     "grunt-drupal-tasks": "~0.9.0",

--- a/app/templates/gdt/package.json
+++ b/app/templates/gdt/package.json
@@ -8,7 +8,9 @@
   },
   "private": true,
   "scripts": {
-    "start": "grunt --timer"
+    "start": "grunt --timer",
+    "stop": "grunt clean:default",
+    "test": "grunt validate && grunt test"
   },
   "dependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
If a theme is specified when calling gadget, add a postinstall script to the package.json so the theme is automatically installed after the project. This facilitates ease in managing all project dependencies from the project root.

@EvanLovely @arithmetric 
