### PR TITLE
Switch from Drush master to track Drush 8.x

### DIFF
--- a/app/templates/gdt/composer.json
+++ b/app/templates/gdt/composer.json
@@ -4,7 +4,7 @@
     "require-dev": {
         "behat/mink-zombie-driver": "~1.2",
         "drupal/drupal-extension": "~3.0",
-        "drush/drush": "dev-master",
+        "drush/drush": "8.x",
         "phpmd/phpmd": "~2.1",
         "squizlabs/php_codesniffer": "~1.5",
         "drupal/coder": "7.2.3"


### PR DESCRIPTION
Drush 9.x has been cut and could lead to experimental changes. Let's stick with stable.

This change will require follow-up in #54 
