### PR TITLE
Upstream execution of tests that use Gadget as a sub-generator fail

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -31,6 +31,11 @@ module.exports = yeoman.Base.extend({
       this.options.drupalDistro = distros[this.options.drupalDistro];
     }
 
+    if (this.options.hasOwnProperty('drupal-distro') && typeof this.options['drupal-distro'] === 'string') {
+      var distros = require('../app/distros');
+      this.options['drupalDistro'] = distros[this.options['drupal-distro']];
+    }
+
     var prompts = require('../lib/prompts');
     prompts = _.filter(prompts, function (item) {
       return _.isUndefined(self.options[item.name]);


### PR DESCRIPTION
For reasons I do not understand, when an upstream generator attempts to pass options to Gadget, camelCase fails, being converted to hyphenates. In the case of drupalDistro, this requires some extra massaging.

This change gets tests workable, we might want to consider if Yeoman has a practice on hyphenate options we should be generally respecting.
