### PR TITLE
Add stmp to makefile(s) when mailhog option is present

### DIFF
--- a/app/distros/drupal.js
+++ b/app/distros/drupal.js
@@ -34,6 +34,11 @@ function init() {
       tokens.cacheVersion = options['cacheVersion'];
     }
 
+    if (options['smtpVersion']) {
+      tokens.smtp = 'smtp';
+      tokens.smtpVersion = options['smtpVersion'];
+    }
+
     yo.fs.copyTpl(
       yo.templatePath('drupal/drupal/project.make.yml'),
       yo.destinationPath('src/project.make.yml'),

--- a/app/distros/drupal.js
+++ b/app/distros/drupal.js
@@ -27,6 +27,7 @@ function init() {
       drupalDistroRelease: options.drupalDistroRelease,
       coreCompatibility: options.drupalDistroVersion,
       cache: false,
+      smtp: false
     };
 
     if (options['cacheVersion']) {

--- a/app/distros/openatrium.js
+++ b/app/distros/openatrium.js
@@ -31,7 +31,8 @@ function init() {
       drupalDistroRelease: releaseVersion,
       coreCompatibility: options.drupalDistroVersion,
       projectName: options.projectName,
-      cache: false
+      cache: false,
+      smtp: false
     };
 
     if (options['cacheVersion']) {

--- a/app/distros/openatrium.js
+++ b/app/distros/openatrium.js
@@ -39,6 +39,11 @@ function init() {
       tokens.cacheVersion = options['cacheVersion'];
     }
 
+    if (options['smtpVersion']) {
+      tokens.smtp = 'smtp';
+      tokens.smtpVersion = options['smtpVersion'];
+    }
+
     yo.fs.copyTpl(
       yo.templatePath('drupal/' + options.drupalDistro.id + '/project-main.make.yml'),
       yo.destinationPath('src/project.make.yml'),

--- a/app/index.js
+++ b/app/index.js
@@ -103,6 +103,28 @@ module.exports = yeoman.Base.extend({
       }
     },
 
+    smtpVersion: function() {
+      if (options.mailhog) {
+        if (options['offline']) {
+          options.smtpVersion = 0;
+        }
+        else {
+          var done = this.async();
+          require('../lib/drupalProjectVersion')
+            .latestRelease('smtp', options.majorVersionForUpdateSystem, done, function(err, version, done) {
+              if (err) {
+                this.log.error(err);
+                return done(err);
+              }
+              options.smtpVersion = version.substr(4);
+
+              done();
+            }.bind(this)
+          );
+        }
+      }
+    },
+
     gdtBase: function() {
       this.fs.copy(
         path.resolve(this.templatePath('gdt'), '**', '*'),

--- a/app/templates/drupal/drupal/project.make.yml
+++ b/app/templates/drupal/drupal/project.make.yml
@@ -8,10 +8,11 @@ defaults:
 
 projects:
 
-  #Drupal Core
+  # Drupal Core
   drupal:
     version: "<%= drupalDistroRelease %>"
 
   # Project-specific Dependencies
 
 <% if (cache) { %><%- include ../make-cache -%><% } %>
+<% if (smtp) { %><%- include ../make-smtp -%><% } %>

--- a/app/templates/drupal/make-cache.ejs
+++ b/app/templates/drupal/make-cache.ejs
@@ -1,5 +1,4 @@
-# Provides cache drivers for <%= cache %>. Module installation not required.
-
+  # Provides cache drivers for <%= cache %>. Module installation not required.
   <%= cache %>:
     version: "<%= cacheVersion %>"
 

--- a/app/templates/drupal/make-smtp.ejs
+++ b/app/templates/drupal/make-smtp.ejs
@@ -1,0 +1,3 @@
+  # Provides SMTP mail transport support.
+  <%= smtp %>:
+    version: "<%= smtpVersion %>"

--- a/app/templates/drupal/openatrium/project-specific.make.yml
+++ b/app/templates/drupal/openatrium/project-specific.make.yml
@@ -15,3 +15,4 @@ defaults:
 
 projects:
 <% if (cache) { %><%- include ../make-cache -%><% } %>
+<% if (smtp) { %><%- include ../make-smtp -%><% } %>

--- a/app/templates/drupal/project-distro.make.yml
+++ b/app/templates/drupal/project-distro.make.yml
@@ -20,3 +20,4 @@ projects:
 # Project-specific Dependencies
 
 <% if (cache) { %><%- include make-cache -%><% } %>
+<% if (smtp) { %><%- include make-smtp -%><% } %>


### PR DESCRIPTION
A followup here may be changing the option name `mailhog` that is passed by composed generators to be more generically applicable. That would be a breaking change (though trivial in scope) so left for later enhancement.
