### PR TITLE
Use rsync:tempbuild on atrium dev if GDT sees rsync available.

### DIFF
--- a/app/templates/drupal/openatrium/7.x/bin/grunt/atrium.js
+++ b/app/templates/drupal/openatrium/7.x/bin/grunt/atrium.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
         // Ensure Atrium's dependencies are placed in the openatrium profile directory tree.
         'drush:make-atrium',
         'clean:default',
-        require('grunt-drupal-tasks/lib/util').canRsync ? 'rsync:tempbuild' : 'copy:tempbuild',
+        require('grunt-drupal-tasks/lib/util').canRsync() ? 'rsync:tempbuild' : 'copy:tempbuild',
         'clean:temp'
       ]);
     });

--- a/app/templates/drupal/openatrium/7.x/bin/grunt/atrium.js
+++ b/app/templates/drupal/openatrium/7.x/bin/grunt/atrium.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
         // Ensure Atrium's dependencies are placed in the openatrium profile directory tree.
         'drush:make-atrium',
         'clean:default',
-        'copy:tempbuild',
+        require('grunt-drupal-tasks/lib/util').canRsync ? 'rsync:tempbuild' : 'copy:tempbuild',
         'clean:temp'
       ]);
     });


### PR DESCRIPTION
Updates "forked" atrium dev build process to reap the rsync benefits.
