### PR TITLE
Update package.json to pull in grunt 1.0.0

### DIFF
--- a/app/templates/gdt/package.json
+++ b/app/templates/gdt/package.json
@@ -13,8 +13,8 @@
     "test": "grunt validate && grunt test"
   },
   "dependencies": {
-    "grunt": "~0.4.5",
-    "grunt-drupal-tasks": "~0.9.0",
+    "grunt": "^1.0.0",
+    "grunt-drupal-tasks": "~0.10.0",
     "zombie": "^2.5.1"
   }
 }


### PR DESCRIPTION
Otherwise the existence of a stable version of grunt chokes up some of the dependencies on npm install.
