### PR TITLE
Bump version of Coder and rely on it to bring in phpcs 2

### DIFF
--- a/app/templates/gdt/composer.json
+++ b/app/templates/gdt/composer.json
@@ -4,10 +4,9 @@
     "require-dev": {
         "behat/mink-zombie-driver": "~1.2",
         "drupal/drupal-extension": "~3.0",
+        "drupal/coder": "^8.2",
         "drush/drush": "8.x",
-        "phpmd/phpmd": "~2.1",
-        "squizlabs/php_codesniffer": "~1.5",
-        "drupal/coder": "7.2.3"
+        "phpmd/phpmd": "~2.1"
     },
     "require": {
         "roave/security-advisories": "dev-master"


### PR DESCRIPTION
Matching the D8 phpcs/coder dependencies for all projects.
