### PR TITLE
Add out-of-box, optional support for Composer Manager

### DIFF
--- a/app/distros/drupal.js
+++ b/app/distros/drupal.js
@@ -23,11 +23,9 @@ function init() {
   };
 
   module.drushMakeFile = function(yo, options, done) {
-    var tokens = {
-      drupalDistroRelease: options.drupalDistroRelease,
-      coreCompatibility: options.drupalDistroVersion,
-      cache: false,
-    };
+    var tokens = options;
+    options.coreCompatibility = options.drupalDistroVersion;
+    options.cache = false;
 
     if (options['cacheVersion']) {
       tokens.cache = options['cacheInternal'];

--- a/app/distros/drupal.js
+++ b/app/distros/drupal.js
@@ -24,8 +24,8 @@ function init() {
 
   module.drushMakeFile = function(yo, options, done) {
     var tokens = options;
-    options.coreCompatibility = options.drupalDistroVersion;
-    options.cache = false;
+    tokens.coreCompatibility = options.drupalDistroVersion;
+    tokens.cache = false;
 
     if (options['cacheVersion']) {
       tokens.cache = options['cacheInternal'];

--- a/app/distros/openatrium.js
+++ b/app/distros/openatrium.js
@@ -27,10 +27,10 @@ function init() {
     var releaseVersion = options.drupalDistroRelease.match(/^\d+\.x\-(.+)/)[1];
 
     var tokens = options;
-    options.drupalDistroName = module.id,
-    options.drupalDistroRelease = releaseVersion,
-    options.coreCompatibility = options.drupalDistroVersion;
-    options.cache = false;
+    tokens.drupalDistroName = module.id,
+    tokens.drupalDistroRelease = releaseVersion,
+    tokens.coreCompatibility = options.drupalDistroVersion;
+    tokens.cache = false;
 
     if (options['cacheVersion']) {
       tokens.cache = options['cacheInternal'];

--- a/app/distros/openatrium.js
+++ b/app/distros/openatrium.js
@@ -26,13 +26,11 @@ function init() {
   module.drushMakeFile = function(yo, options, done) {
     var releaseVersion = options.drupalDistroRelease.match(/^\d+\.x\-(.+)/)[1];
 
-    var tokens = {
-      drupalDistroName: module.id,
-      drupalDistroRelease: releaseVersion,
-      coreCompatibility: options.drupalDistroVersion,
-      projectName: options.projectName,
-      cache: false
-    };
+    var tokens = options;
+    options.drupalDistroName = module.id,
+    options.drupalDistroRelease = releaseVersion,
+    options.coreCompatibility = options.drupalDistroVersion;
+    options.cache = false;
 
     if (options['cacheVersion']) {
       tokens.cache = options['cacheInternal'];

--- a/app/index.js
+++ b/app/index.js
@@ -103,6 +103,27 @@ module.exports = yeoman.Base.extend({
       }
     },
 
+    composerManager: function() {
+      if (options['useComposerManager']) {
+        if (options['offline']) {
+          options.composerManagerVersion = 0;
+        }
+        else {
+          var done = this.async();
+          require('../lib/drupalProjectVersion')
+            .latestRelease('composer_manager', options.majorVersionForUpdateSystem, done, function(err, version, done) {
+              if (err) {
+                this.log.error(err);
+                return done(err);
+              }
+              options.composerManagerVersion = version.substr(4);
+              done();
+            }.bind(this)
+          );
+        }
+      }
+    },
+
     gdtBase: function() {
       this.fs.copy(
         path.resolve(this.templatePath('gdt'), '**', '*'),
@@ -228,6 +249,15 @@ module.exports = yeoman.Base.extend({
         + chalk.red(options.drupalDistroRelease) + '.\n');
       var done = this.async();
       options.drupalDistro.drushMakeFile(this, options, done);
+    },
+
+    composerManager: function() {
+      if (options['useComposerManager']) {
+        this.fs.copy(
+          this.templatePath('grunt/composer-manager.js'),
+          this.destinationPath('bin/grunt/composer-manager.js')
+        );
+      }
     }
   },
 

--- a/app/index.js
+++ b/app/index.js
@@ -46,6 +46,9 @@ module.exports = yeoman.Base.extend({
       if (!options['cacheInternal']) {
         options.cacheInternal = 'database';
       }
+      if (!options['useComposerManager']) {
+        options.useComposerManager = false;
+      }
       this.log("\nOk, I'm going to start assembling this project...");
       done();
     }.bind(this));

--- a/app/templates/drupal/drupal/8.x/bin/grunt/composer-manager.js
+++ b/app/templates/drupal/drupal/8.x/bin/grunt/composer-manager.js
@@ -1,0 +1,51 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-shell');
+
+  grunt.config.set(['shell', 'composer-manager'], {
+    command: 'php ./modules/contrib/composer_manager/scripts/init.php',
+    options: {
+      execOptions: {
+        cwd: '<%= config.buildPaths.html %>'
+      }
+    }
+  });
+
+  grunt.config.set(['shell', 'composer-drupal-rebuild'], {
+    command: 'composer drupal-rebuild',
+    options: {
+      execOptions: {
+        cwd: '<%= config.buildPaths.html %>'
+      }
+    }
+  });
+
+  grunt.config.set(['shell', 'composer-lock'], {
+    command: 'composer update --lock',
+    options: {
+      execOptions: {
+        cwd: '<%= config.buildPaths.html %>'
+      }
+    }
+  });
+
+  var message = 'Run composer manager to aggregate and process module composer.json files.';
+  grunt.registerTask('composer-manager', message, function() {
+    var tasks = [
+      'shell:composer-manager',
+      'shell:composer-drupal-rebuild',
+      'shell:composer-lock'
+    ];
+
+    // Add `pre-composer-manager` and `post-composer-manager` options to
+    // Gruntconfig scripts.
+    require('grunt-drupal-tasks/lib/scripts')(grunt)
+      .eventify(grunt.config('config.scripts'), this.name, this.name, tasks);
+
+    grunt.task.run(tasks);
+  });
+
+  require('grunt-drupal-tasks/lib/help')(grunt).add({
+    task: 'composer-manager',
+    group: 'Build Process'
+  });
+};

--- a/app/templates/drupal/drupal/project.make.yml
+++ b/app/templates/drupal/drupal/project.make.yml
@@ -8,10 +8,11 @@ defaults:
 
 projects:
 
-  #Drupal Core
+  # Drupal Core
   drupal:
     version: "<%= drupalDistroRelease %>"
 
   # Project-specific Dependencies
-
-<% if (cache) { %><%- include ../make-cache -%><% } %>
+  <% if (cache) { %><%- include ../make-cache -%><% } %>
+  <% if (useComposerManager) { %>composer_manager:
+    version: "<%= composerManagerVersion %>"<% } %>

--- a/app/templates/drupal/make-cache.ejs
+++ b/app/templates/drupal/make-cache.ejs
@@ -1,5 +1,4 @@
-# Provides cache drivers for <%= cache %>. Module installation not required.
-
+  ### Provides cache drivers for <%= cache %>. Module installation not required.
   <%= cache %>:
     version: "<%= cacheVersion %>"
 

--- a/app/templates/grunt/composer-manager.js
+++ b/app/templates/grunt/composer-manager.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+
   grunt.loadNpmTasks('grunt-shell');
 
   grunt.config.set(['shell', 'composer-manager'], {
@@ -19,7 +20,7 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.config.set(['shell', 'composer-lock'], {
+  grunt.config.set(['shell', 'composer-update'], {
     command: 'composer update --lock',
     options: {
       execOptions: {
@@ -33,7 +34,7 @@ module.exports = function(grunt) {
     var tasks = [
       'shell:composer-manager',
       'shell:composer-drupal-rebuild',
-      'shell:composer-lock'
+      'shell:composer-update'
     ];
 
     // Add `pre-composer-manager` and `post-composer-manager` options to
@@ -44,6 +45,11 @@ module.exports = function(grunt) {
     grunt.task.run(tasks);
   });
 
+  // Rewire the scaffold task to follow with composer-manager.
+  grunt.task.renameTask('scaffold', 'scaffold-pre-composer-manager');
+  grunt.registerTask('scaffold', ['scaffold-pre-composer-manager', 'composer-manager']);
+
+  // Wire up the `grunt help` command.
   require('grunt-drupal-tasks/lib/help')(grunt).add({
     task: 'composer-manager',
     group: 'Build Process'

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -58,10 +58,10 @@ var prompts = [
   {
     type: 'confirm',
     name: 'useComposerManager',
-    message: 'Use Composer Manager to manage composer dependencies?';
+    message: 'Use Composer Manager to manage composer dependencies?',
     default: false,
     when: function(answers) {
-      return answers['drupalDistroVersion'].versions == '8.x';
+      return answers['drupalDistroVersion'] === '8.x';
     }
   }
 ];

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -59,7 +59,7 @@ var prompts = [
     type: 'confirm',
     name: 'useComposerManager',
     message: 'Use Composer Manager to manage composer dependencies?',
-    default: false,
+    default: true,
     when: function(answers) {
       return answers['drupalDistroVersion'] === '8.x';
     }

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -23,7 +23,6 @@ var prompts = [
     name: 'projectDescription',
     message: 'One-line project description?'
   },
-
   {
     type: 'list',
     name: 'drupalDistro',
@@ -54,6 +53,15 @@ var prompts = [
     },
     choices: function(answers) {
       return answers['drupalDistro'].versions;
+    }
+  },
+  {
+    type: 'confirm',
+    name: 'useComposerManager',
+    message: 'Use Composer Manager to manage composer dependencies?';
+    default: false,
+    when: function(answers) {
+      return answers['drupalDistroVersion'].versions == '8.x';
     }
   }
 ];

--- a/test/generator.int.test.js
+++ b/test/generator.int.test.js
@@ -7,14 +7,18 @@ var test = require('yeoman-test');
 
 describe('gadget:app', function () {
   before(function (done) {
+    var appDir = path.join(os.tmpdir(), './temp-test');
+    console.log('Test output: ' + appDir);
+
     test.run(path.join(__dirname, '../app'))
-      .inDir(path.join(os.tmpdir(), './temp-test'))
+      .inDir(appDir)
       .withOptions({
         'skip-install': true,
         projectName: 'drupal8',
         projectDescription: 'test drupal8 project',
         drupalDistro: 'drupal',
-        drupalDistroVersion: '8.x'
+        drupalDistroVersion: '8.x',
+        useComposerManager: true
       })
       .on('end', done);
   });
@@ -29,7 +33,9 @@ describe('gadget:app', function () {
       // General-purpose behat.yml is not overridden.
       'test/behat.yml',
       // Behat example tests are present.
-      'test/features/example.feature'
+      'test/features/example.feature',
+      // Composer Manager modification is in place.
+      'bin/grunt/composer-manager.js'
     ]);
   });
 });


### PR DESCRIPTION
Per discussion with @jhedstrom , this is an implementation of formal composer manager support for Gadget.
- Adds a default-no prompt to add support
- Adds composer manager to makefile if used
- Appends a composer manager process to the end of the makefile.

That all seems fine, but I really dislike the performance penalty and wonder if using composer to directly manage dependencies could be that much worse than Drush Make + Composer.

![Timer Chart for Build Process](https://i.gyazo.com/853efb568f5a522533b1d7631ce3a3a7.png)

composer-lock was an earlier name for composer-update. As you can see, the composer-update itself doubles the length of time the build process takes for my test whose makefile only adds three modules to a plain D8 codebase.
