### PR TITLE
Composer workflow for Drupal 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ system with the Grunt Drupal Tasks kit.
 
 * Automatically uses the latest version of Grunt Drupal Tasks.
 * Select from Drupal 7, Drupal 8, or Atrium 2.
-* Configures a Drush Makefile so your grunt build process is ready to assemble a working codebase immediately! Uses the latest version of Drupal or Atrium.
+* For Drupal 8, creates a `composer.json` file that requires the lates stable Drupal, Drupal Console, and Drush.
+* For Drupal 7, Configures a Drush Makefile so your grunt build process is ready to assemble a working codebase immediately! Uses the latest version of Drupal or Atrium.
 * Provides numerous configuration files for Git, IDE's, and other tools for Drupal best practices out-of-the-box.
 * The entire Grunt Drupal Tasks features list is ready to go, include Behat Testing, Static Analysis, and Continuous-Integration readiness.
 

--- a/app/index.js
+++ b/app/index.js
@@ -245,11 +245,14 @@ module.exports = yeoman.Base.extend({
     },
 
     drushMakefile: function () {
-      this.log('Setting up Drush makefile to install Drupal Distribution '
-        + options.drupalDistro.option.name + ' version '
-        + chalk.red(options.drupalDistroRelease) + '.\n');
-      var done = this.async();
-      options.drupalDistro.drushMakeFile(this, options, done);
+      // Make files only for 7.x and less.
+      if (options.drupalDistroRelease < 8) {
+        this.log('Setting up Drush makefile to install Drupal Distribution '
+          + options.drupalDistro.option.name + ' version '
+          + chalk.red(options.drupalDistroRelease) + '.\n');
+        var done = this.async();
+        options.drupalDistro.drushMakeFile(this, options, done);
+      }
     }
   },
 

--- a/app/templates/drupal/drupal/8.x/Gruntconfig.json
+++ b/app/templates/drupal/drupal/8.x/Gruntconfig.json
@@ -5,7 +5,11 @@
   "domain": "project.vm",
   "packages": {
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**"]
+    "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make", "vendor/**", "composer.*"],
+    "dest": {
+      "docroot": "build/html",
+      "devResources": ""
+    }
   },
   "phpcs": {
     "path": "vendor/bin/phpcs"

--- a/app/templates/drupal/drupal/8.x/Gruntconfig.json
+++ b/app/templates/drupal/drupal/8.x/Gruntconfig.json
@@ -1,0 +1,26 @@
+{
+  "srcPaths": {
+    "drupal": "src"
+  },
+  "domain": "project.vm",
+  "packages": {
+    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
+    "projFiles": ["README*", "bin/**"]
+  },
+  "phpcs": {
+    "path": "vendor/bin/phpcs"
+  },
+  "phpmd": {
+    "path": "vendor/bin/phpmd"
+  },
+  "drush": {
+    "cmd": "vendor/bin/drush"
+  },
+  "behat": {
+    "flags": "--tags ~@wip"
+  },
+  "eslint": true,
+  "scripts": {
+    "update": "<%= config.drush.cmd %> <%= config.alias %> features-revert-all -yv"
+  }
+}

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -4,7 +4,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://packagist.drupal-composer.org"
+            "url": "https://packages.drupal.org/8"
         }
     ],
     "require": {

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -37,7 +37,7 @@
             "build/html/modules/contrib/{$name}": ["type:drupal-module"],
             "build/html/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/html/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/contrib/{$name}": ["type:drupal-drush"]
+            "build/drush/contrib/{$name}": ["type:drupal-drush"]
         }
     }
 }

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -20,6 +20,7 @@
         "drush/drush": "^8",
         "drupal/console": "~0.10",
         "phpmd/phpmd": "~2.1",
+        "phpunit/phpunit": "~4.8",
         "drupal/coder": "^8.2"
     },
     "conflict": {

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -1,17 +1,42 @@
 {
     "name": "client/project",
-    "description": "{Project} drupal codebase for {client}.",
+    "description": "{Project} Drupal codebase for {client}.",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packagist.drupal-composer.org"
+        }
+    ],
+    "require": {
+        "composer/installers": "^1.0.20",
+        "drupal-composer/drupal-scaffold": "^2.0.1",
+        "cweagans/composer-patches": "~1.0",
+        "drupal/core": "~8.1",
+        "roave/security-advisories": "dev-master"
+    },
     "require-dev": {
         "behat/mink-zombie-driver": "~1.2",
         "drupal/drupal-extension": "~3.0",
         "drush/drush": "^8",
+        "drupal/console": "~0.10",
         "phpmd/phpmd": "~2.1",
-        "drupal/coder": "^8.2",
-        "guzzlehttp/guzzle" : "^6.0@dev",
-        "symfony/dependency-injection": "2.7.*",
-        "symfony/event-dispatcher": "2.7.*"
+        "drupal/coder": "^8.2"
     },
-    "require": {
-        "roave/security-advisories": "dev-master"
+    "conflict": {
+        "drupal/drupal": "*"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts": {
+        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
+    },
+    "extra": {
+        "installer-paths": {
+            "build/html/core": ["type:drupal-core"],
+            "build/html/modules/contrib/{$name}": ["type:drupal-module"],
+            "build/html/profiles/contrib/{$name}": ["type:drupal-profile"],
+            "build/html/themes/contrib/{$name}": ["type:drupal-theme"],
+            "drush/contrib/{$name}": ["type:drupal-drush"]
+        }
     }
 }

--- a/test/generator.int.test.js
+++ b/test/generator.int.test.js
@@ -22,8 +22,7 @@ describe('gadget:app', function () {
   it('creates files for Drupal 8.x', function() {
     assert.file([
       'README.md',
-      // Distribution-specific makefile.
-      'src/project.make.yml',
+      'composer.json',
       // gtd scaffolding dotfiles are copying.
       'src/modules/.gitkeep',
       // General-purpose behat.yml is not overridden.


### PR DESCRIPTION
There will be a corresponding PR in GDT.

For Drupal 8, this stubs out a `composer.json` file that will install Drupal, Drupal Console, and Drush.
