### PR TITLE
Adjust behat alias to use project name 

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -133,6 +133,11 @@ module.exports = yeoman.Base.extend({
           globOptions: { dot: true }
         }
       );
+      this.fs.copyTpl(
+        path.resolve(this.templatePath('gdt'), 'test', 'behat.yml'),
+        path.resolve(this.destinationRoot(), 'test', 'behat.yml'),
+        options
+      );
     }
   },
 

--- a/app/templates/gdt/test/behat.yml
+++ b/app/templates/gdt/test/behat.yml
@@ -14,7 +14,7 @@ default:
     Drupal\DrupalExtension:
       blackbox: ~
       drush:
-        alias: 'local'
+        alias: '<%= projectName %>'
       drupal:
         drupal_root: './build/html'
       api_driver: 'drupal'


### PR DESCRIPTION
This better aligns with aliases produced by other generators in phase2 environment.

As near as I can tell there isn't a good reasonable default here.
Path to docroot of site would be good if it could be relative but based [on the docs](http://behat-drupal-extension.readthedocs.io/en/3.1/drush.html) that looks like it needs to be from root.
