### PR TITLE
Add phpunit to composer

### DIFF
--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -2,15 +2,19 @@
     "name": "client/project",
     "description": "{Project} drupal codebase for {client}.",
     "require-dev": {
+        "behat/mink": "~1.7",
         "behat/mink-zombie-driver": "~1.2",
+        "behat/mink-goutte-driver": "~1.2",
         "drupal/drupal-extension": "~3.0",
+        "jcalderonzumba/gastonjs": "~1.0.2",
+        "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
+        "mikey179/vfsStream": "~1.2",
         "drush/drush": "^8",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "^8.2",
         "guzzlehttp/guzzle" : "^6.0@dev",
         "symfony/dependency-injection": "2.7.*",
-        "symfony/event-dispatcher": "2.7.*",
-        "phpunit/phpunit": "~4.8"
+        "symfony/event-dispatcher": "2.7.*"
     },
     "require": {
         "roave/security-advisories": "dev-master"

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -9,7 +9,8 @@
         "drupal/coder": "^8.2",
         "guzzlehttp/guzzle" : "^6.0@dev",
         "symfony/dependency-injection": "2.7.*",
-        "symfony/event-dispatcher": "2.7.*"
+        "symfony/event-dispatcher": "2.7.*",
+        "phpunit/phpunit": "~4.8"
     },
     "require": {
         "roave/security-advisories": "dev-master"

--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -9,6 +9,7 @@
         "jcalderonzumba/gastonjs": "~1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsStream": "~1.2",
+        "phpunit/phpunit": "~4.8",
         "drush/drush": "^8",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "^8.2",


### PR DESCRIPTION
Composer doesn't pull in require-dev from dependencies, so phpunit is not picked up from Drupal core and is needed to run automated tests.
