### PR TITLE
Test Node v4, 5, 6, 7. Drop v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: node_js
 node_js:
+  - '7'
+  - '6'
   - '5'
   - '4'
-  - '0.12'
 install:
   - npm install -g grunt-cli mocha
   - ls -lRa


### PR DESCRIPTION
v0.12 is EOL, and we aren't testing against Node 6 or 7. Let's see what happens.