### PR TITLE
Fixing variable name typo and removing unreachable code

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,13 +37,11 @@ module.exports.fsExistsSync = function(path) {
   }
   else {
     try {
-      fs.accessSync(filename);
+      fs.accessSync(path);
       return true;
     }
     catch(ex) {
       return false;
     }
   }
-
-  return false;
 }


### PR DESCRIPTION
From our debugging call yesterday