### PR TITLE
Bump Drupal Console version to 1.0 RC candidate.

### DIFF
--- a/app/templates/drupal/drupal/8.x/composer.json
+++ b/app/templates/drupal/drupal/8.x/composer.json
@@ -24,7 +24,7 @@
         "mikey179/vfsStream": "~1.2",
         "phpunit/phpunit": "~4.8",
         "drush/drush": "^8",
-        "drupal/console": "~0.10",
+        "drupal/console": "1.0.0-rc15",
         "phpmd/phpmd": "~2.1",
         "phpunit/phpunit": "~4.8",
         "drupal/coder": "^8.2"


### PR DESCRIPTION
There has been a lot of work towards getting Drupal Console to a 1.0 release, with many improvements.

Let's cue that by fixing the latest release and plan to switch to 1.0 with our stable 1.0 release if it comes out in time.