### PR TITLE
Automatically determine the core version based on latest stable release.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -201,6 +201,11 @@ module.exports = Generator.extend({
       if (isNewProject) {
         // Project hasn't been generated yet, so start with composer template.
         composer = this.fs.readJSON('composer.json');
+
+        // Overwrite new project composer.json with a new core version.
+        if (composer.require['drupal/core'] && options.drupalDistroRelease) {
+          composer.require['drupal/core'] = require('../lib/drupalProjectVersion').toMinorRange(options.drupalDistroRelease);
+        }
       }
       else {
         // Use original composer file if project already generated.
@@ -214,6 +219,7 @@ module.exports = Generator.extend({
         var done = this.async();
         composer = options.drupalDistro.modifyComposer(this, options, composer, isNewProject, done);
       }
+
       this.fs.writeJSON('composer.json', composer);
     },
 

--- a/generators/app/templates/drupal/drupal/8.x/composer.json
+++ b/generators/app/templates/drupal/drupal/8.x/composer.json
@@ -11,7 +11,7 @@
         "composer/installers": "^1.0.20",
         "drupal-composer/drupal-scaffold": "^2.0.1",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "~8.1",
+        "drupal/core": true,
         "roave/security-advisories": "dev-master"
     },
     "require-dev": {

--- a/generators/lib/distros/drupal.js
+++ b/generators/lib/distros/drupal.js
@@ -19,7 +19,7 @@ function init() {
   module.description = 'This project is built directly on Drupal Core, it is not leveraging other distributions. For more information visit the [Drupal Project homepage](http://drupal.org/project/drupal).';
 
   module.releaseVersion = function(majorVersion, done, cb) {
-    require('../../lib/drupalProjectVersion').latestRelease(module.id, majorVersion, done, cb);
+    require('../../lib/drupalProjectVersion').latestReleaseStable(module.id, majorVersion, done, cb);
   };
 
   module.drushMakeFile = function(yo, options, done) {

--- a/generators/lib/distros/openatrium.js
+++ b/generators/lib/distros/openatrium.js
@@ -20,7 +20,7 @@ function init() {
   module.description = 'This project is built on [' + module.option.name + '](http://openatrium.com) for more information visit the [Atrium Project Homepage](https://drupal.org/project/openatrium).';
 
   module.releaseVersion = function(majorVersion, done, cb) {
-    require('../../lib/drupalProjectVersion').latestRelease(module.id, majorVersion, done, cb);
+    require('../../lib/drupalProjectVersion').latestReleaseStable(module.id, majorVersion, done, cb);
   };
 
   module.drushMakeFile = function(yo, options, done) {

--- a/generators/lib/drupalProjectVersion.js
+++ b/generators/lib/drupalProjectVersion.js
@@ -1,19 +1,43 @@
+'use strict';
+
+/**
+ * Retrieve Drupal project release data.
+ *
+ * @todo extract to a library.
+ * @todo switch to promises.
+ */
+
 var request = require('request');
 var xml2js = require('xml2js');
+var _ = require('lodash');
 
 function init() {
   var module = {};
 
-  function latestRelease(project, majorVersion, done, cb) {
+  /**
+   * Project Release Data Cache
+   *
+   * Cache the data associated with any given major version of a project for the
+   * extent of a single generator run. We cache it already parsed to an object.
+   */
+  var cache = {};
+
+  function loadReleaseData(project, majorVersion, done, cb) {
+    var cid = project + majorVersion;
+    if (cache[cid]) {
+      return cb(null, cache[cid], done);
+    }
+
     var releaseUri = 'https://updates.drupal.org/release-history/';
-    request(releaseUri + project + '/' + majorVersion, function (error, response, body) {
+    request(releaseUri + project + '/' + majorVersion, function(error, response, body) {
       if (!error && response.statusCode == 200 && body.length) {
         xml2js.parseString(body, function (err, result) {
-          if (!err && result && result.project && result.project.releases && result.project.releases[0] && result.project.releases[0].release && result.project.releases[0].release[0] && result.project.releases[0].release[0].version) {
-            cb(null, result.project.releases[0].release[0].version[0], done);
+          if (!err && result && result.project) {
+            cache[cid] = result.project;
+            return cb(null, result.project, done);
           }
           else {
-            cb('Could not parse latest version of ' + project + ' for Drush makefile. Received:\n', result, done);
+            return cb('Could not parse latest version of ' + project + '. Received:\n', result, done);
           }
         });
       }
@@ -22,7 +46,47 @@ function init() {
         if (error.code == 'ETIMEDOUT') {
           msg += 'Failure was caused by a network timeout. If testing Gadget, try running with --offline.\n';
         }
-        cb(msg, null, done);
+        return cb(msg, null, done);
+      }
+    });
+  }
+
+  function latestRelease(project, majorVersion, done, cb) {
+    loadReleaseData(project, majorVersion, done, function(err, result, done) {
+      if (!err && result.releases
+        && result.releases[0]
+        && result.releases[0].release
+        && result.releases[0].release[0]
+        && result.releases[0].release[0].version
+      ) {
+        return cb(null, result.releases[0].release[0].version[0], done);
+      }
+      else {
+        err = 'No version data found.';
+      }
+      if (err) {
+        return cb(err, null, done);
+      }
+    });
+  }
+
+  function latestReleaseStable(project, majorVersion, done, cb) {
+    loadReleaseData(project, majorVersion, done, function(err, result, done) {
+      if (!err && result.releases
+        && result.releases[0]
+        && result.releases[0].release
+      ) {
+        var release = _.find(result.releases[0].release, function(release) {
+          return !release.version_extra;
+        })
+        return cb(null, release.version[0], done);
+      }
+      else {
+        err = 'No version data found.';
+      }
+
+      if (err) {
+        return cb(err, null, done);
       }
     });
   }
@@ -32,8 +96,28 @@ function init() {
     return version.slice(0, version.indexOf('.'));
   }
 
+  // Convert a semver version from '8.2.6' to a minor range '^8.2'.
+  function toMinorRange(version) {
+    var regex = /^(\d+\.\d+)\.\d+/;
+    var range = version.match(regex);
+    return '^' + range[1];
+  }
+
+  /**
+   * Determine if we have successfully cached the release data.
+   */
+  function isCached(project, majorVersion) {
+    var cid = project+majorVersion;
+    return cache[cid] && cache[cid].short_name[0] == project && cache[cid].api_version[0] == majorVersion;
+  }
+
   module.latestRelease = latestRelease;
+  module.latestReleaseStable = latestReleaseStable;
   module.numericCoreVersion = numericCoreVersion;
+  module.toMinorRange = toMinorRange;
+  // This function facilitates testing & troubleshooting.
+  module.isCached = isCached;
+
 
   return module;
 }

--- a/test/drupal-org-api.test.js
+++ b/test/drupal-org-api.test.js
@@ -1,0 +1,71 @@
+var _ = require('lodash');
+var assert = require('yeoman-assert');
+var drupal = require('../generators/lib/drupalProjectVersion');
+
+describe('Drupal.org API Client', function() {
+  describe('latestRelease', function() {
+    it ('should retrieve the latest Drupal 8 core release', function(done) {
+      drupal.latestRelease('drupal', '8.x', done, function(err, result, done) {
+        assert.ok(!err && result, 'Retrieved a result for Drupal 8 release.');
+        if (err) {
+          console.error(err);
+        }
+        done();
+      });
+    })
+
+    it ('should retrieve the latest Drupal 7 core release', function(done) {
+      drupal.latestRelease('drupal', '7.x', done, function(err, result, done) {
+        assert.ok(!err && result, 'Retrieved a result for Drupal 7 release.');
+        if (err) {
+          console.error(err);
+        }
+        done();
+      });
+    });
+  });
+
+  describe('latestReleaseStable', function() {
+    it ('should retrieve the latest Drupal 8 core release', function(done) {
+      drupal.latestReleaseStable('drupal', '8.x', done, function(err, result, done) {
+        assert.ok(!err && result, 'Retrieved a result for Drupal 8 release.');
+        if (err) {
+          console.error(err);
+        }
+        done();
+      });
+    })
+
+    it ('should retrieve the latest Drupal 7 core release', function(done) {
+      drupal.latestReleaseStable('drupal', '7.x', done, function(err, result, done) {
+        assert.ok(!err && result, 'Retrieved a result for Drupal 7 release.');
+        if (err) {
+          console.error(err);
+        }
+        done();
+      });
+    });
+  });
+
+  describe('isCached', function() {
+    it ('should retrieve follow-up requests from the cache.', function() {
+      assert.ok(drupal.isCached('drupal', '8.x'), 'Previously retrieved drupal 8.x data.');
+    });
+  });
+
+  describe('numericCoreVersion', function() {
+    it ('should convert a version number to the core version digits', function() {
+      assert.equal(8, drupal.numericCoreVersion('8.2.6'), '8.2.6 returns 8');
+    });
+    it ('should convert a major version to the core version digits', function() {
+      assert.equal(8, drupal.numericCoreVersion('8.x'), '8.x returns 8');
+    });
+  });
+
+  describe('toMinorRange', function() {
+    it ('should convert a version number to a minor range', function() {
+      assert.equal('^8.2', drupal.toMinorRange('8.2.6'), '8.2.6 becomes ^8.2');
+    });
+  });
+
+});


### PR DESCRIPTION
This change modifies the generators to dynamically set the Drupal core version when doing a Drupal 8.x build (as opposed to an Octane build). It checks the Drupal core update feed for the latest stable release, converts it to a minor range such as `^8.2`, and injects that into the composer.json if their is a `require['drupal/core']` property present.

As part of this, we get some caching on data retrieval from Drupal.org for the lifetime of the generator run, which I will also use elsewhere. And tests.

This will also address Drupal 7.x and Atrium 2.x projects, avoiding setting up pre-releases, not that there's like to be alphas or rc's of either.