### PR TITLE
Standardize path to theme for Gruntconfig.json and package.json

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -217,7 +217,7 @@ module.exports = Generator.extend({
         pkg.scripts = {};
       }
       if (!pkg.scripts['postinstall'] && options['themePath']) {
-        pkg.scripts['postinstall'] = 'cd ' + options.themePath + ' && npm install';
+        pkg.scripts['postinstall'] = 'cd ' + path.join(options.themePath, options.themeName) + ' && npm install';
       }
 
       this.fs.writeJSON('package.json', pkg);
@@ -233,7 +233,7 @@ module.exports = Generator.extend({
       // Process theme options and insert into Gruntconfig.json.
       if (options.themeName && options.themePath) {
         var themeOpts = {
-          path: "<%= config.srcPaths.drupal %>/themes/" + options.themeName
+          path: path.join(options.themePath, options.themeName)
         };
 
         if (options.themeType === 'compass') {


### PR DESCRIPTION
Looks like in some of the recent refactoring, we shifted the themePath to be more of a themeBasePath. This continues with that change so the package.json postinstall properly descends into the theme directory for npm install.

At the same time, I noticed that Gruntconfig.json's themes configuration was working despite that change... because it was ignoring the themePath and constructing a path based on gdt conventions and the themeName.