### PR TITLE
Surface more context for HTTP request errors for proejct info.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -65,7 +65,7 @@ module.exports = Generator.extend({
         var done = this.async();
         options.drupalDistro.releaseVersion(options.drupalDistroVersion, done, function(err, version, done) {
           if (err) {
-            this.log.error(err);
+            this.env.error('Could not retrieve distribution project info: ' + err);
             return done(err);
           }
           options.drupalDistroRelease = version;
@@ -86,7 +86,7 @@ module.exports = Generator.extend({
           drupalOrgApi.latestRelease(options.cacheInternal, options.drupalDistroVersion, done,
             function(err, version, done) {
               if (err) {
-                this.log.error(err);
+                this.env.error('Could not retrieve project info for selected cache system: ' + err);
                 return done(err);
               }
               options.cacheVersion = version.substr(4);
@@ -107,7 +107,7 @@ module.exports = Generator.extend({
           drupalOrgApi.latestRelease('smtp', options.drupalDistroVersion, done,
             function(err, version, done) {
               if (err) {
-                this.log.error(err);
+                this.env.error('Could not retrieve project info for selected mail system: ' + err);
                 return done(err);
               }
               options.smtpVersion = version.substr(4);

--- a/generators/lib/drupalProjectVersion.js
+++ b/generators/lib/drupalProjectVersion.js
@@ -66,7 +66,7 @@ function init() {
         return cb(null, result.releases[0].release[0].version[0], done);
       }
       else {
-        err = 'No version data found.';
+        err = 'No version data found. This may be a an error in communication with updates.drupal.org.';
       }
       if (err) {
         return cb(err, null, done);
@@ -86,7 +86,7 @@ function init() {
         return cb(null, release.version[0], done);
       }
       else {
-        err = 'No version data found.';
+        err = 'No version data found. This may be a an error in communication with updates.drupal.org.';
       }
 
       if (err) {


### PR DESCRIPTION
Fixes #101

```
╚╩═▶ fig run --rm yo gadget

     _-----_     ╭──────────────────────────╮
    |       |    │ Welcome to Gadget 1.1.0, │
    |--(o)--|    │ the gnarly generator for │
   `---------´   │    Grunt Drupal Tasks!   │
    ( _´U`_ )    ╰──────────────────────────╯
    /___A___\   /
     |  ~  |
   __'.___.'__
 ´   `  |° ´ Y `

? Machine-name of your project? generated
? One-line project description? Generated Drupal codebase.
? Which Drupal distribution would you like to use? Drupal
? Which version of Drupal would you like to use? Drupal 8

Ok, I'm going to start assembling this project...
Error gadget --no-insight --skip-install

Could not retrieve distribution project info: No version data found. This may be a an error in communication with updates.drupal.org.
```