### PR TITLE
Adds a project-specific phpunit.xml file.

### DIFF
--- a/generators/app/templates/drupal/drupal/8.x/phpunit.xml
+++ b/generators/app/templates/drupal/drupal/8.x/phpunit.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="build/html/core/tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         checkForUnintentionallyCoveredCode="false">
+<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
+ https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
+ result printer that links to the html output results for functional tests.
+ Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
+ using the command line you can add
+ - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
+ should be no spaces between the hyphens).
+-->
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value="http://project.vm"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value=""/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp"/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>./src/modules/*/tests/src/Unit</directory>
+      <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
+      <exclude>./vendor</exclude>
+    </testsuite>
+    <testsuite name="kernel">
+      <directory>./src/modules/*/tests/src/Kernel</directory>
+      <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
+      <exclude>./vendor</exclude>
+    </testsuite>
+    <testsuite name="functional">
+      <directory>./src/modules/*/tests/src/Functional</directory>
+      <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
+      <exclude>./vendor</exclude>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <directory>./src/modules/*/tests/src/FunctionalJavascript</directory>
+      <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
+      <exclude>./vendor</exclude>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+    <listener class="\Drupal\Tests\Listeners\DrupalStandardsListener">
+    </listener>
+    <listener class="\Drupal\Tests\Listeners\DrupalComponentTestListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports only on custom code. This intentionally excludes core and contrib files. -->
+  <filter>
+    <whitelist>
+      <directory>./src/modules</directory>
+      <!-- By definition test classes have no tests. -->
+      <exclude>
+        <directory suffix="Test.php">./</directory>
+        <directory suffix="TestBase.php">./</directory>
+        <!-- Exclude core and contrib code from test coverage. -->
+        <directory>./build/html/modules/contrib</directory>
+        <directory>./build/html/core</directory>
+      </exclude>
+     </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
- Fixes #108

This still needs work, as I'm forgetting how/when db credentials are available. We need to properly populate this bit of the file:

```xml
    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
    <env name="SIMPLETEST_DB" value=""/>
```