### PR TITLE
Update Drupal Console so it may use Drupal 8.4.x

### DIFF
--- a/generators/app/templates/drupal/drupal/8.x/composer.json
+++ b/generators/app/templates/drupal/drupal/8.x/composer.json
@@ -24,7 +24,7 @@
         "mikey179/vfsstream": "~1.2",
         "phpunit/phpunit": ">=4.8.28 <5",
         "drush/drush": "^8",
-        "drupal/console": "1.0.0-rc16",
+        "drupal/console": "~1.0",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "^8.2"
     },


### PR DESCRIPTION
Drupal Console 1.0.0-rc16 uses Symfony **>=2.7 <3.0** which is not compatible with Drupal 8.4.x (prefers Symfony ~3.0).

The current stable release of Drupal Console expect using Symfony **~2.8|~3.0**.

This commit updates the required version to the **~1.0** branch, allowing