### PR TITLE
Update zombie version for NodeJS 8.x

### DIFF
--- a/generators/app/templates/gdt/package.json
+++ b/generators/app/templates/gdt/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "grunt": "^1.0.0",
     "grunt-drupal-tasks": "^1.0",
-    "zombie": "^2.5.1"
+    "zombie": "^5.0.7"
   }
 }


### PR DESCRIPTION
After updating NodeJS to the las version (8.9.4), npm can't install the *zombie* package because it fails to download the dependencies.

It appears that the problem was that the *contextify* package can't be build.

```
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at emitTwo (events.js:126:13)
gyp ERR! stack     at ChildProcess.emit (events.js:214:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
gyp ERR! System Linux 4.9.0-5-amd64
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /tmp/gadget-error/node_modules/contextify
gyp ERR! node -v v8.9.4
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! contextify@0.1.15 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the contextify@0.1.15 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

The problem appears to be solved with the current version of the *zombie* package.