### PR TITLE
Update to Drush 9

### DIFF
--- a/generators/app/templates/drupal/drupal/8.x/composer.json
+++ b/generators/app/templates/drupal/drupal/8.x/composer.json
@@ -11,7 +11,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core": "~8.0",
+        "drupal/core": "~8.4",
         "roave/security-advisories": "dev-master"
     },
     "require-dev": {
@@ -23,7 +23,7 @@
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsstream": "~1.2",
         "phpunit/phpunit": ">=4.8.28 <5",
-        "drush/drush": "^8",
+        "drush/drush": "^9",
         "drupal/console": "~1.0",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "^8.2"


### PR DESCRIPTION
- Fixes #121 

I'm seeing these errors (something is passing in an empty string argument somehow), but they are probably GDT-related:

```
Notice: Uninitialized string offset: 0 in vendor/drush/drush/src/Preflight/ArgsRemapper.php on line 50
```

```
Notice: Uninitialized string offset: 0 in vendor/drush/drush/src/Preflight/ArgsPreprocessor.php on line 72
```

Everything else seems to work as expected in manual testing.